### PR TITLE
React Native builds for IOS - set s.homepage for RNEosEcc

### DIFF
--- a/ios/RNEosEcc.podspec
+++ b/ios/RNEosEcc.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNEosEcc
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/author/RNEosEcc.git"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "raphael.gaudreault@eva.coop" }


### PR DESCRIPTION
Hello, 

I found the issue with building FIO SDK for IOS.

`pod install` is failing due to missing required attribute `homepage` in `RNEosEcc.podspec`. 

```
blocksoft@BlockSoftsMac ios % pod install
Detected React Native module pods for BVLinearGradient, RNAwesomeCardIO, RNBackgroundFetch, RNBlocksoftRandom, RNCAsyncStorage, RNCMaskedView, RNDeviceInfo, RNEosEcc, RNExitApp, RNFS, RNFirebase, RNGestureHandler, RNKeychain, RNLocalize, RNOS, RNPermissions, RNReanimated, RNSVG, RNScreens, RNShare, RNTextSize, RNZipArchive, ReactNativeExceptionHandler, SajjadBlurOverlay, TcpSockets, TouchID, lottie-ios, lottie-react-native, react-native-background-timer, react-native-blur, react-native-camera, react-native-fbsdk, react-native-image-picker, react-native-image-resizer, react-native-netinfo, react-native-orientation, react-native-randombytes, react-native-safe-area-context, react-native-sqlite-storage, react-native-udp, react-native-version-check, react-native-webview, and toolbar-android
Analyzing dependencies
Fetching podspec for `DoubleConversion` from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`
Fetching podspec for `Folly` from `../node_modules/react-native/third-party-podspecs/Folly.podspec`
[!] The `RNEosEcc` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | source: The version should be included in the Git tag.
    - WARN  | description: The description is equal to the summary.
```

Proposed PR is resolving this issue. 