### PR TITLE
FIP-21 Add FIO staking 

### DIFF
--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -1,6 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.Constants = void 0;
 class Constants {
 }
 exports.Constants = Constants;
@@ -24,6 +23,7 @@ Constants.feeNoAddressOperation = [
 Constants.rawAbiAccountName = [
     'fio.address',
     'fio.reqobt',
+    'fio.staking',
     'fio.token',
     'eosio',
     'fio.fee',

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -21,6 +21,7 @@ export class Constants {
   public static rawAbiAccountName: string[] = [
     'fio.address',
     'fio.reqobt',
+    'fio.staking',
     'fio.token',
     'eosio',
     'fio.fee',


### PR DESCRIPTION
This PR adds the fio.staking abi to the list of accounts used by the sdk,

DO NOT deploy this change before the fio.staking contract has been added to the FIO protocol in operations or test net.