### PR TITLE
BD-2992. Add encryptOptions to push tx method. Encrypt content field for push tx.

### DIFF
--- a/lib/FIOSDK.js
+++ b/lib/FIOSDK.js
@@ -912,11 +912,32 @@ class FIOSDK {
      * @param account Account name
      * @param action Name of action
      * @param data JSON object with params for action
+     * @param encryptOptions JSON object with params for encryption
      */
-    pushTransaction(account, action, data) {
-        data.tpid = this.getTechnologyProviderId(data.tpid);
-        const pushTransaction = new SignedTransactions.PushTransaction(action, account, data);
-        return pushTransaction.execute(this.privateKey, this.publicKey, this.returnPreparedTrx);
+    pushTransaction(account, action, data, encryptOptions = {}) {
+        return __awaiter(this, void 0, void 0, function* () {
+            data.tpid = this.getTechnologyProviderId(data.tpid);
+            if (data.content && !encryptOptions.key) {
+                switch (action) {
+                    case 'newfundsreq': {
+                        const payerKey = yield this.getFioPublicAddress(data.payer_fio_address);
+                        encryptOptions.key = payerKey.public_address;
+                        encryptOptions.contentType = 'new_funds_content';
+                        break;
+                    }
+                    case 'recordobt': {
+                        const payeeKey = yield this.getFioPublicAddress(data.payee_fio_address);
+                        encryptOptions.key = payeeKey.public_address;
+                        encryptOptions.contentType = 'record_obt_data_content';
+                        break;
+                    }
+                    default:
+                    //
+                }
+            }
+            const pushTransaction = new SignedTransactions.PushTransaction(action, account, data, encryptOptions);
+            return pushTransaction.execute(this.privateKey, this.publicKey, this.returnPreparedTrx);
+        });
     }
     /**
      * @ignore
@@ -1040,7 +1061,7 @@ class FIOSDK {
             case 'getMultiplier':
                 return this.getMultiplier();
             case 'pushTransaction':
-                return this.pushTransaction(params.account, params.action, params.data);
+                return this.pushTransaction(params.account, params.action, params.data, params.encryptOptions);
         }
     }
     /**

--- a/lib/transactions/signed/PushTransaction.js
+++ b/lib/transactions/signed/PushTransaction.js
@@ -4,7 +4,7 @@ exports.PushTransaction = void 0;
 const constants_1 = require("../../utils/constants");
 const SignedTransaction_1 = require("./SignedTransaction");
 class PushTransaction extends SignedTransaction_1.SignedTransaction {
-    constructor(action, account, data) {
+    constructor(action, account, data, encryptOptions = {}) {
         super();
         this.ENDPOINT = 'chain/push_transaction';
         this.ACTION = '';
@@ -14,9 +14,14 @@ class PushTransaction extends SignedTransaction_1.SignedTransaction {
             this.ACCOUNT = account;
         }
         this.data = data;
+        this.encryptOptions = encryptOptions;
     }
     getData() {
-        return Object.assign(Object.assign({}, this.data), { actor: this.data.actor != null && this.data.actor != '' ? this.data.actor : this.getActor() });
+        const data = Object.assign({}, this.data);
+        if (data.content && this.encryptOptions && this.encryptOptions.key && this.encryptOptions.contentType) {
+            data.content = this.getCipherContent(this.encryptOptions.contentType, data.content, this.privateKey, this.encryptOptions.key);
+        }
+        return Object.assign(Object.assign({}, data), { actor: this.data.actor != null && this.data.actor !== '' ? this.data.actor : this.getActor() });
     }
 }
 exports.PushTransaction = PushTransaction;

--- a/src/transactions/signed/PushTransaction.ts
+++ b/src/transactions/signed/PushTransaction.ts
@@ -1,24 +1,43 @@
 import { Constants } from '../../utils/constants'
 import { SignedTransaction } from './SignedTransaction'
 
+export interface EncryptOptions { key?: string; contentType?: string }
+
 export class PushTransaction extends SignedTransaction {
 
   public ENDPOINT: string = 'chain/push_transaction'
   public ACTION: string = ''
   public ACCOUNT: string = Constants.defaultAccount
   public data: any
+  public encryptOptions: EncryptOptions
 
-  constructor(action: string, account: string, data: any) {
+  constructor(
+    action: string,
+    account: string,
+    data: any,
+    encryptOptions: EncryptOptions = {},
+  ) {
     super()
     this.ACTION = action
     if (account) { this.ACCOUNT = account }
     this.data = data
+    this.encryptOptions = encryptOptions
   }
 
   public getData(): any {
+    const data = { ...this.data }
+    if (data.content && this.encryptOptions && this.encryptOptions.key && this.encryptOptions.contentType) {
+      data.content = this.getCipherContent(
+        this.encryptOptions.contentType,
+        data.content,
+        this.privateKey,
+        this.encryptOptions.key,
+      )
+    }
+
     return {
-      ...this.data,
-      actor: this.data.actor != null && this.data.actor != '' ? this.data.actor : this.getActor(),
+      ...data,
+      actor: this.data.actor != null && this.data.actor !== '' ? this.data.actor : this.getActor(),
     }
   }
 


### PR DESCRIPTION
now to send fio request for example you could:
```
await fioSdk.genericAction('pushTransaction', {
        action: 'newfundsreq',
        account: 'fio.reqobt',
        data: {
          payer_fio_address: 'payer-address@domain',
          payee_fio_address: 'payee-address@domain',
          content: {
            payee_public_address: 'pubKey',
            amount: 2,
            chain_code: 'FIO',
            token_code: 'FIO',
            memo: 'hello',
            hash: '',
            offline_url: ''
          },
          max_fee: 200000000
        }
      })
```