### PR TITLE
Fix. DASH-584 FIOSDK crash fixes

### DIFF
--- a/lib/FIOSDK.js
+++ b/lib/FIOSDK.js
@@ -44,6 +44,34 @@ class FIOSDK {
      * @param returnPreparedTrx flag indicate that it should return prepared transaction or should be pushed to server.
      */
     constructor(privateKey, publicKey, apiUrls, fetchjson, registerMockUrl = '', technologyProviderId = '', returnPreparedTrx = false) {
+        this.proxyHandle = {
+            // We save refrenece to our class inside the object
+            main: this,
+            /**
+             * The apply will be fired each time the function is called
+             * @param  target Called function
+             * @param  scope  Scope from where function was called
+             * @param  args   Arguments passed to function
+             * @return        Results of the function
+             */
+            apply: function (target, scope, args) {
+                return __awaiter(this, void 0, void 0, function* () {
+                    // Remember that you have to exclude methods which you are gonna use
+                    // inside here to avoid “too much recursion” error
+                    const setAbi = (accountName) => __awaiter(this, void 0, void 0, function* () {
+                        if (!Transactions_1.Transactions.abiMap.get(accountName)) {
+                            const response = yield this.main.getAbi(accountName);
+                            Transactions_1.Transactions.abiMap.set(response.account_name, response);
+                        }
+                    });
+                    const setAbiPromises = constants_1.Constants.rawAbiAccountName.map(accountName => setAbi(accountName));
+                    yield Promise.all(setAbiPromises).catch(error => { throw error; });
+                    // Here we bind method with our class by accessing reference to instance
+                    const results = target.bind(this.main)(...args);
+                    return results;
+                });
+            }
+        };
         /**
          * Defines whether SignedTransaction would execute or return prepared transaction
          */
@@ -57,17 +85,13 @@ class FIOSDK {
         this.publicKey = publicKey;
         this.technologyProviderId = technologyProviderId;
         this.returnPreparedTrx = returnPreparedTrx;
-        for (const accountName of constants_1.Constants.rawAbiAccountName) {
-            if (!Transactions_1.Transactions.abiMap.get(accountName)) {
-                this.getAbi(accountName)
-                    .then((response) => {
-                    Transactions_1.Transactions.abiMap.set(response.account_name, response);
-                })
-                    .catch((error) => {
-                    throw error;
-                });
-            }
-        }
+
+        const methods = Object.getOwnPropertyNames(FIOSDK.prototype);
+        // Replace all methods with Proxy methods
+        // Find and remove constructor as we don't need Proxy on it
+        methods.filter(method => !constants_1.Constants.classMethodsToExcludeFromProxy.includes(method)).forEach(methodName => {
+            this[methodName] = new Proxy(this[methodName], this.proxyHandle);
+        });
     }
     /**
      * @ignore
@@ -235,72 +259,6 @@ class FIOSDK {
      */
     static SUFToAmount(suf) {
         return parseInt(`${suf}`, 10) / this.SUFUnit;
-    }
-    /**
-     * // how to instantiate fetchJson parameter
-     * i.e.
-     * fetch = require('node-fetch')
-     *
-     * const fetchJson = async (uri, opts = {}) => {
-     *  return fetch(uri, opts)
-     * }
-     *
-     * @param privateKey the fio private key of the client sending requests to FIO API.
-     * @param publicKey the fio public key of the client sending requests to FIO API.
-     * @param apiUrls the url or list of urls to the FIO API.
-     * @param fetchjson - the module to use for HTTP Post/Get calls (see above for example)
-     * @param registerMockUrl the url to the mock server
-     * @param technologyProviderId Default FIO Address of the wallet which generates transactions.
-     * @param returnPreparedTrx flag indicate that it should return prepared transaction or should be pushed to server.
-     */
-    constructor(privateKey, publicKey, apiUrls, fetchjson, registerMockUrl = '', technologyProviderId = '', returnPreparedTrx = false) {
-        this.proxyHandle = {
-            // We save refrenece to our class inside the object
-            main: this,
-            /**
-             * The apply will be fired each time the function is called
-             * @param  target Called function
-             * @param  scope  Scope from where function was called
-             * @param  args   Arguments passed to function
-             * @return        Results of the function
-             */
-            apply: function (target, scope, args) {
-                return __awaiter(this, void 0, void 0, function* () {
-                    // Remember that you have to exclude methods which you are gonna use
-                    // inside here to avoid “too much recursion” error
-                    const setAbi = (accountName) => __awaiter(this, void 0, void 0, function* () {
-                        if (!Transactions_1.Transactions.abiMap.get(accountName)) {
-                            const response = yield this.main.getAbi(accountName);
-                            Transactions_1.Transactions.abiMap.set(response.account_name, response);
-                        }
-                    });
-                    const setAbiPromises = constants_1.Constants.rawAbiAccountName.map(accountName => setAbi(accountName));
-                    yield Promise.all(setAbiPromises).catch(error => { throw error; });
-                    // Here we bind method with our class by accessing reference to instance
-                    const results = target.bind(this.main)(...args);
-                    return results;
-                });
-            }
-        };
-        /**
-         * Defines whether SignedTransaction would execute or return prepared transaction
-         */
-        this.returnPreparedTrx = false;
-        this.transactions = new Transactions_1.Transactions();
-        Transactions_1.Transactions.baseUrls = Array.isArray(apiUrls) ? apiUrls : [apiUrls];
-        Transactions_1.Transactions.FioProvider = fiojs_1.Fio;
-        Transactions_1.Transactions.fetchJson = fetchjson;
-        this.registerMockUrl = registerMockUrl;
-        this.privateKey = privateKey;
-        this.publicKey = publicKey;
-        this.technologyProviderId = technologyProviderId;
-        this.returnPreparedTrx = returnPreparedTrx;
-        const methods = Object.getOwnPropertyNames(FIOSDK.prototype);
-        // Replace all methods with Proxy methods
-        // Find and remove constructor as we don't need Proxy on it
-        methods.filter(method => !constants_1.Constants.classMethodsToExcludeFromProxy.includes(method)).forEach(methodName => {
-            this[methodName] = new Proxy(this[methodName], this.proxyHandle);
-        });
     }
     /**
      * Retrieves the FIO public key assigned to the FIOSDK instance.

--- a/lib/FIOSDK.js
+++ b/lib/FIOSDK.js
@@ -237,6 +237,72 @@ class FIOSDK {
         return parseInt(`${suf}`, 10) / this.SUFUnit;
     }
     /**
+     * // how to instantiate fetchJson parameter
+     * i.e.
+     * fetch = require('node-fetch')
+     *
+     * const fetchJson = async (uri, opts = {}) => {
+     *  return fetch(uri, opts)
+     * }
+     *
+     * @param privateKey the fio private key of the client sending requests to FIO API.
+     * @param publicKey the fio public key of the client sending requests to FIO API.
+     * @param apiUrls the url or list of urls to the FIO API.
+     * @param fetchjson - the module to use for HTTP Post/Get calls (see above for example)
+     * @param registerMockUrl the url to the mock server
+     * @param technologyProviderId Default FIO Address of the wallet which generates transactions.
+     * @param returnPreparedTrx flag indicate that it should return prepared transaction or should be pushed to server.
+     */
+    constructor(privateKey, publicKey, apiUrls, fetchjson, registerMockUrl = '', technologyProviderId = '', returnPreparedTrx = false) {
+        this.proxyHandle = {
+            // We save refrenece to our class inside the object
+            main: this,
+            /**
+             * The apply will be fired each time the function is called
+             * @param  target Called function
+             * @param  scope  Scope from where function was called
+             * @param  args   Arguments passed to function
+             * @return        Results of the function
+             */
+            apply: function (target, scope, args) {
+                return __awaiter(this, void 0, void 0, function* () {
+                    // Remember that you have to exclude methods which you are gonna use
+                    // inside here to avoid “too much recursion” error
+                    const setAbi = (accountName) => __awaiter(this, void 0, void 0, function* () {
+                        if (!Transactions_1.Transactions.abiMap.get(accountName)) {
+                            const response = yield this.main.getAbi(accountName);
+                            Transactions_1.Transactions.abiMap.set(response.account_name, response);
+                        }
+                    });
+                    const setAbiPromises = constants_1.Constants.rawAbiAccountName.map(accountName => setAbi(accountName));
+                    yield Promise.all(setAbiPromises).catch(error => { throw error; });
+                    // Here we bind method with our class by accessing reference to instance
+                    const results = target.bind(this.main)(...args);
+                    return results;
+                });
+            }
+        };
+        /**
+         * Defines whether SignedTransaction would execute or return prepared transaction
+         */
+        this.returnPreparedTrx = false;
+        this.transactions = new Transactions_1.Transactions();
+        Transactions_1.Transactions.baseUrls = Array.isArray(apiUrls) ? apiUrls : [apiUrls];
+        Transactions_1.Transactions.FioProvider = fiojs_1.Fio;
+        Transactions_1.Transactions.fetchJson = fetchjson;
+        this.registerMockUrl = registerMockUrl;
+        this.privateKey = privateKey;
+        this.publicKey = publicKey;
+        this.technologyProviderId = technologyProviderId;
+        this.returnPreparedTrx = returnPreparedTrx;
+        const methods = Object.getOwnPropertyNames(FIOSDK.prototype);
+        // Replace all methods with Proxy methods
+        // Find and remove constructor as we don't need Proxy on it
+        methods.filter(method => !constants_1.Constants.classMethodsToExcludeFromProxy.includes(method)).forEach(methodName => {
+            this[methodName] = new Proxy(this[methodName], this.proxyHandle);
+        });
+    }
+    /**
      * Retrieves the FIO public key assigned to the FIOSDK instance.
      */
     getFioPublicKey() {

--- a/lib/transactions/Transactions.js
+++ b/lib/transactions/Transactions.js
@@ -290,6 +290,16 @@ class Transactions {
             }
             try {
                 const res = yield Transactions.fetchJson(baseUrl + endPoint, options);
+                if (res === undefined) {
+                    const error = new Error(`Error: Can't reach the site ${baseUrl}${endPoint}. Possible wrong url.`);
+                    return {
+                        data: {
+                            code: 500,
+                            message: error.message,
+                        },
+                        isError: true,
+                    };
+                }
                 if (!res.ok) {
                     const error = new Error(`Error ${res.status} while fetching ${baseUrl + endPoint}`);
                     try {

--- a/lib/transactions/Transactions.js
+++ b/lib/transactions/Transactions.js
@@ -340,7 +340,7 @@ class Transactions {
     }
     multicastServers(endpoint, body, fetchOptions) {
         return __awaiter(this, void 0, void 0, function* () {
-            const res = yield (0, utils_1.asyncWaterfall)((0, utils_1.shuffleArray)(Transactions.baseUrls.map((apiUrl) => () => this.executeCall(apiUrl, endpoint, body, fetchOptions))));
+            const res = yield (0, utils_1.asyncWaterfall)(Transactions.baseUrls.map((apiUrl) => () => this.executeCall(apiUrl, endpoint, body, fetchOptions)));
             if (res.isError) {
                 const error = new FioError(res.errorMessage || res.data.message);
                 error.json = res.data.json;

--- a/lib/transactions/queries/Query.js
+++ b/lib/transactions/queries/Query.js
@@ -23,7 +23,12 @@ class Query extends Transactions_1.Transactions {
             this.publicKey = publicKey;
             this.privateKey = privateKey;
             if (!this.isEncrypted) {
-                return this.multicastServers(this.getEndPoint(), JSON.stringify(this.getData()));
+                try {
+                    return this.multicastServers(this.getEndPoint(), JSON.stringify(this.getData()));
+                }
+                catch (error) {
+                    throw error;
+                }
             }
             else {
                 try {

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -41,3 +41,4 @@ Constants.rawAbiAccountName = [
 Constants.multiplier = 1000000000;
 Constants.defaultAccount = 'fio.address';
 Constants.defaultExpirationOffset = 180;
+Constants.classMethodsToExcludeFromProxy = ['constructor', 'getAbi'];

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -41,4 +41,22 @@ Constants.rawAbiAccountName = [
 Constants.multiplier = 1000000000;
 Constants.defaultAccount = 'fio.address';
 Constants.defaultExpirationOffset = 180;
-Constants.classMethodsToExcludeFromProxy = ['constructor', 'getAbi'];
+Constants.classMethodsToExcludeFromProxy = [
+    'constructor',
+    'SUFUnit',
+    'derivedPublicKey',
+    'isChainCodeValid',
+    'isTokenCodeValid',
+    'isFioAddressValid',
+    'isFioDomainValid',
+    'isFioPublicKeyValid',
+    'isPublicAddressValid',
+    'amountToSUF',
+    'SUFToAmount',
+    'getFioPublicKey',
+    'getTechnologyProviderId',
+    'setSignedTrxReturnOption',
+    'setApiUrls',
+    'getMultiplier',
+    'getAbi'
+];

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -47,7 +47,9 @@ function asyncWaterfall(asyncFuncs, timeoutMs = PROMISE_TIMEOUT) {
                 }));
             }
             try {
-                const result = yield Promise.race(promises);
+                const result = yield Promise.any(promises);
+                if (result.isError)
+                    throw result.data;
                 if (result === 'async_waterfall_timed_out') {
                     promises.pop();
                     --pending;

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -30,7 +30,7 @@ function asyncWaterfall(asyncFuncs, timeoutMs = PROMISE_TIMEOUT) {
                 }));
             }
             try {
-                const result = yield Promise.any(promises);
+                const result = yield Promise.race(promises);
                 if (result.isError)
                     throw result.data;
                 if (result === 'async_waterfall_timed_out') {

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -9,26 +9,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.asyncWaterfall = exports.shuffleArray = void 0;
+exports.asyncWaterfall = void 0;
 const PROMISE_TIMEOUT = 5000;
 const snooze = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-function shuffleArray(array) {
-    let currentIndex = array.length;
-    let temporaryValue;
-    let randomIndex;
-    // While there remain elements to shuffle...
-    while (currentIndex !== 0) {
-        // Pick a remaining element...
-        randomIndex = Math.floor(Math.random() * currentIndex);
-        currentIndex -= 1;
-        // And swap it with the current element.
-        temporaryValue = array[currentIndex];
-        array[currentIndex] = array[randomIndex];
-        array[randomIndex] = temporaryValue;
-    }
-    return array;
-}
-exports.shuffleArray = shuffleArray;
 function asyncWaterfall(asyncFuncs, timeoutMs = PROMISE_TIMEOUT) {
     return __awaiter(this, void 0, void 0, function* () {
         let pending = asyncFuncs.length;

--- a/src/transactions/Transactions.ts
+++ b/src/transactions/Transactions.ts
@@ -19,7 +19,7 @@ import { RawTransaction } from '../entities/RawTransaction'
 import { ValidationError } from '../entities/ValidationError'
 
 import { validate } from '../utils/validation'
-import { asyncWaterfall, shuffleArray } from '../utils/utils'
+import { asyncWaterfall } from '../utils/utils'
 import { Constants } from '../utils/constants'
 
 type FetchJson = (uri: string, opts?: object) => any
@@ -463,10 +463,8 @@ export class Transactions {
 
   public async multicastServers(endpoint: string, body: string | null, fetchOptions?: any): Promise<any> {
     const res = await asyncWaterfall(
-      shuffleArray(
-        Transactions.baseUrls.map((apiUrl) => () =>
-          this.executeCall(apiUrl, endpoint, body, fetchOptions),
-        ),
+      Transactions.baseUrls.map((apiUrl) => () =>
+        this.executeCall(apiUrl, endpoint, body, fetchOptions),
       ),
     )
 

--- a/src/transactions/Transactions.ts
+++ b/src/transactions/Transactions.ts
@@ -405,6 +405,16 @@ export class Transactions {
     }
     try {
       const res = await Transactions.fetchJson(baseUrl + endPoint, options)
+      if (res === undefined) {
+        const error = new Error(`Error: Can't reach the site ${baseUrl}${endPoint}. Possible wrong url.`)
+        return {
+          data: {
+            code: 500,
+            message: error.message,
+          },
+          isError: true,
+        }
+      }
       if (!res.ok) {
         const error: Error & {
           json?: FioErrorJson,

--- a/src/transactions/queries/Query.ts
+++ b/src/transactions/queries/Query.ts
@@ -14,7 +14,11 @@ export abstract class Query<T> extends Transactions {
     this.publicKey = publicKey
     this.privateKey = privateKey
     if (!this.isEncrypted) {
-      return this.multicastServers(this.getEndPoint(), JSON.stringify(this.getData()))
+      try {
+        return this.multicastServers(this.getEndPoint(), JSON.stringify(this.getData()))
+      } catch (error) {
+        throw error
+      }
     } else {
       try {
         const result = await this.multicastServers(this.getEndPoint(), JSON.stringify(this.getData()))

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -41,4 +41,6 @@ export class Constants {
   public static defaultAccount: string = 'fio.address'
 
   public static defaultExpirationOffset = 180
+
+  public static classMethodsToExcludeFromProxy: string[] = ['constructor', 'getAbi'];
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -42,5 +42,23 @@ export class Constants {
 
   public static defaultExpirationOffset = 180
 
-  public static classMethodsToExcludeFromProxy: string[] = ['constructor', 'getAbi'];
+  public static classMethodsToExcludeFromProxy: string[] = [
+    'constructor',
+    'SUFUnit',
+    'derivedPublicKey',
+    'isChainCodeValid',
+    'isTokenCodeValid',
+    'isFioAddressValid',
+    'isFioDomainValid',
+    'isFioPublicKeyValid',
+    'isPublicAddressValid',
+    'amountToSUF',
+    'SUFToAmount',
+    'getFioPublicKey',
+    'getTechnologyProviderId',
+    'setSignedTrxReturnOption',
+    'setApiUrls',
+    'getMultiplier',
+    'getAbi'
+  ]
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -27,7 +27,7 @@ export async function asyncWaterfall(
       )
     }
     try {
-      const result = await Promise.any(promises)
+      const result = await Promise.race(promises)
       if (result.isError) throw result.data
       if (result === 'async_waterfall_timed_out') {
         promises.pop()

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,7 +1,7 @@
 const PROMISE_TIMEOUT = 5000;
 
 const snooze: Function = (ms: number) =>
-  new Promise((resolve: Function) => setTimeout(resolve, ms))
+  new Promise((resolve: (...args: any[]) => void) => setTimeout(resolve, ms))
 
 export function shuffleArray(array: Array<any>) {
   let currentIndex = array.length
@@ -47,7 +47,8 @@ export async function asyncWaterfall(
       )
     }
     try {
-      const result = await Promise.race(promises)
+      const result = await Promise.any(promises)
+      if (result.isError) throw result.data
       if (result === 'async_waterfall_timed_out') {
         promises.pop()
         --pending

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -3,26 +3,6 @@ const PROMISE_TIMEOUT = 5000;
 const snooze: Function = (ms: number) =>
   new Promise((resolve: (...args: any[]) => void) => setTimeout(resolve, ms))
 
-export function shuffleArray(array: Array<any>) {
-  let currentIndex = array.length
-  let temporaryValue
-  let randomIndex
-
-  // While there remain elements to shuffle...
-  while (currentIndex !== 0) {
-    // Pick a remaining element...
-    randomIndex = Math.floor(Math.random() * currentIndex)
-    currentIndex -= 1
-
-    // And swap it with the current element.
-    temporaryValue = array[currentIndex]
-    array[currentIndex] = array[randomIndex]
-    array[randomIndex] = temporaryValue
-  }
-
-  return array
-}
-
 export async function asyncWaterfall(
   asyncFuncs: Array<Function>,
   timeoutMs: number = PROMISE_TIMEOUT,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
       "outDir": "lib",
       "sourceMap": false,
       "strict": true,
-      "target": "es2015"
+      "target": "es2015",
+      "lib": ["ES2021.Promise", "dom"],
     },
     "compileOnSave": true,
     "include": [


### PR DESCRIPTION
- Handle wrong apiUrls address
- Handle error on multicastServers in the Query class
- Remove get/set abi results from constructor to proxy
- Change abi requests from one by one to all at once