### PR TITLE
Feature. DASH-628 Auth permission param in sign/push transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,11 @@ This is the expected Private Key:
 This is the expected Public Key:
 "FIO5kJKNHwctcfUM5XZyiWSqSTM5HTzznJP9F3ZdbhaQAHEVq575o"
 
+## Version 1.9.0
+### Breaking changes:
+- Set new parameter `authPermission` for sign and push transactions
+- `pushTransaction` receives object params instead of multiple arguments
+
 ## Version 1.0.2
 Bug Fix to method: addPublicAddresses - TechnologyProviderId (i.e. TPID), was not being set correctly for this method.
 

--- a/documentation/classes/fiosdk.html
+++ b/documentation/classes/fiosdk.html
@@ -1063,7 +1063,7 @@
 					<a name="pushtransaction" class="tsd-anchor"></a>
 					<h3>push<wbr>Transaction</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">push<wbr>Transaction<span class="tsd-signature-symbol">({</span>account<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, action<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, authPermission<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string | undefined</span>, data<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, encryptOptions<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">EncryptOptions</span><span class="tsd-signature-symbol">})</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">push<wbr>Transaction<span class="tsd-signature-symbol">({</span>account<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, action<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, authPermission<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string | undefined</span>, data<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, encryptOptions<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">EncryptOptions</span><span class="tsd-signature-symbol">, signingAccount<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string | undefined</span>})</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
@@ -1107,6 +1107,12 @@
 									<h5>encryptOptions: <span class="tsd-signature-type">EncryptOptions</span></h5>
 									<div class="tsd-comment tsd-typography">
 										<p>Parameters for encryption</p>
+									</div>
+								</li>
+								<li>
+									<h5>signingAccount: <span class="tsd-signature-type">string | undefined</span></h5>
+									<div class="tsd-comment tsd-typography">
+										<p>Sign transaction account</p>
 									</div>
 								</li>
 							</ul>

--- a/documentation/classes/fiosdk.html
+++ b/documentation/classes/fiosdk.html
@@ -1063,13 +1063,13 @@
 					<a name="pushtransaction" class="tsd-anchor"></a>
 					<h3>push<wbr>Transaction</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">push<wbr>Transaction<span class="tsd-signature-symbol">(</span>account<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, action<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, data<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">push<wbr>Transaction<span class="tsd-signature-symbol">({</span>account<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, action<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, authPermission<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string | undefined</span>, data<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, encryptOptions<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">EncryptOptions</span><span class="tsd-signature-symbol">})</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/fioprotocol/fiosdk_typescript/blob/650dec4/src/FIOSDK.ts#L828">FIOSDK.ts:828</a></li>
+									<li>Defined in <a href="https://github.com/fioprotocol/fiosdk_typescript/blob/6acaa206ed8d0ccd402665088d142ef6b92f60fd/src/FIOSDK.ts#L1393">FIOSDK.ts:L1393</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1092,9 +1092,21 @@
 									</div>
 								</li>
 								<li>
+									<h5>authPermission: <span class="tsd-signature-type">string | undefined</span></h5>
+									<div class="tsd-comment tsd-typography">
+										<p>Auth permision parameter</p>
+									</div>
+								</li>
+								<li>
 									<h5>data: <span class="tsd-signature-type">any</span></h5>
 									<div class="tsd-comment tsd-typography">
 										<p>JSON object with params for action</p>
+									</div>
+								</li>
+								<li>
+									<h5>encryptOptions: <span class="tsd-signature-type">EncryptOptions</span></h5>
+									<div class="tsd-comment tsd-typography">
+										<p>Parameters for encryption</p>
 									</div>
 								</li>
 							</ul>

--- a/lib/FIOSDK.js
+++ b/lib/FIOSDK.js
@@ -1001,7 +1001,7 @@ class FIOSDK {
      * @param data JSON object with params for action
      * @param encryptOptions JSON object with params for encryption
      */
-    pushTransaction({ account, action, data, authPermission, encryptOptions = {}, }) {
+    pushTransaction({ account, action, data, authPermission, encryptOptions = {}, signingAccount, }) {
         return __awaiter(this, void 0, void 0, function* () {
             data.tpid = this.getTechnologyProviderId(data.tpid);
             if (data.content && !encryptOptions.key) {
@@ -1028,6 +1028,7 @@ class FIOSDK {
                 authPermission,
                 data,
                 encryptOptions,
+                signingAccount,
             });
             return pushTransaction.execute(this.privateKey, this.publicKey, this.returnPreparedTrx);
         });
@@ -1175,12 +1176,13 @@ class FIOSDK {
             case 'getMultiplier':
                 return this.getMultiplier();
             case 'pushTransaction':
-                 return this.pushTransaction({
+                return this.pushTransaction({
                     account: params.account,
                     action: params.action,
                     data: params.data,
                     authPermission: params.authPermission,
                     encryptOptions: params.encryptOptions,
+                    signingAccount: params.signingAccount,
                 });
             case 'getAccountPubKey':
                 return this.getAccountPubKey(params.account);

--- a/lib/FIOSDK.js
+++ b/lib/FIOSDK.js
@@ -949,11 +949,15 @@ class FIOSDK {
                 const { fee: stakeFee } = yield this.getFee(EndPoint_1.EndPoint.stakeFioTokens, fioAddress);
                 fee = stakeFee;
             }
-            return this.pushTransaction('fio.staking', 'stakefio', {
-                amount,
-                fio_address: fioAddress,
-                max_fee: fee,
-                tpid: technologyProviderId,
+            return this.pushTransaction({
+                account: 'fio.staking',
+                action: 'stakefio',
+                data: {
+                    amount,
+                    fio_address: fioAddress,
+                    max_fee: fee,
+                    tpid: technologyProviderId,
+                },
             });
         });
     }
@@ -971,11 +975,15 @@ class FIOSDK {
                 const { fee: stakeFee } = yield this.getFee(EndPoint_1.EndPoint.unStakeFioTokens, fioAddress);
                 fee = stakeFee;
             }
-            return this.pushTransaction('fio.staking', 'unstakefio', {
-                amount,
-                fio_address: fioAddress,
-                max_fee: fee,
-                tpid: technologyProviderId,
+            return this.pushTransaction({
+                account: 'fio.staking',
+                action: 'unstakefio',
+                data: {
+                    amount,
+                    fio_address: fioAddress,
+                    max_fee: fee,
+                    tpid: technologyProviderId,
+                },
             });
         });
     }
@@ -993,7 +1001,7 @@ class FIOSDK {
      * @param data JSON object with params for action
      * @param encryptOptions JSON object with params for encryption
      */
-    pushTransaction(account, action, data, encryptOptions = {}) {
+    pushTransaction({ account, action, data, authPermission, encryptOptions = {}, }) {
         return __awaiter(this, void 0, void 0, function* () {
             data.tpid = this.getTechnologyProviderId(data.tpid);
             if (data.content && !encryptOptions.key) {
@@ -1014,7 +1022,13 @@ class FIOSDK {
                     //
                 }
             }
-            const pushTransaction = new SignedTransactions.PushTransaction(action, account, data, encryptOptions);
+            const pushTransaction = new SignedTransactions.PushTransaction({
+                action,
+                account,
+                authPermission,
+                data,
+                encryptOptions,
+            });
             return pushTransaction.execute(this.privateKey, this.publicKey, this.returnPreparedTrx);
         });
     }
@@ -1161,7 +1175,13 @@ class FIOSDK {
             case 'getMultiplier':
                 return this.getMultiplier();
             case 'pushTransaction':
-                return this.pushTransaction(params.account, params.action, params.data, params.encryptOptions);
+                 return this.pushTransaction({
+                    account: params.account,
+                    action: params.action,
+                    data: params.data,
+                    authPermission: params.authPermission,
+                    encryptOptions: params.encryptOptions,
+                });
             case 'getAccountPubKey':
                 return this.getAccountPubKey(params.account);
             case 'getEncryptKey':

--- a/lib/transactions/Transactions.js
+++ b/lib/transactions/Transactions.js
@@ -169,7 +169,7 @@ class Transactions {
             textEncoder,
         });
     }
-    createRawTransaction({ account, action, authPermission, data, publicKey, chainData }) {
+    createRawTransaction({ account, action, authPermission, data, publicKey, chainData, signingAccount }) {
         return __awaiter(this, void 0, void 0, function* () {
             const rawTransaction = new RawTransaction_1.RawTransaction();
             const rawaction = new RawAction_1.RawAction();
@@ -182,6 +182,7 @@ class Transactions {
             rawaction.account = account;
             rawaction.name = action;
             rawaction.data = data;
+            rawaction.actor = signingAccount;
             rawTransaction.actions.push(rawaction);
             if (chainData && chainData.ref_block_num) {
                 this.setRawTransactionExp(rawTransaction, chainData);

--- a/lib/transactions/Transactions.js
+++ b/lib/transactions/Transactions.js
@@ -169,7 +169,7 @@ class Transactions {
             textEncoder,
         });
     }
-    createRawTransaction({ account, action, data, publicKey, chainData }) {
+    createRawTransaction({ account, action, authPermission, data, publicKey, chainData }) {
         return __awaiter(this, void 0, void 0, function* () {
             const rawTransaction = new RawTransaction_1.RawTransaction();
             const rawaction = new RawAction_1.RawAction();
@@ -178,7 +178,7 @@ class Transactions {
             if (!data.actor) {
                 data.actor = actor;
             }
-            rawaction.authorization.push(new Autorization_1.Autorization(data.actor, data.permission));
+            rawaction.authorization.push(new Autorization_1.Autorization(data.actor, authPermission));
             rawaction.account = account;
             rawaction.name = action;
             rawaction.data = data;

--- a/lib/transactions/signed/PushTransaction.js
+++ b/lib/transactions/signed/PushTransaction.js
@@ -4,7 +4,7 @@ exports.PushTransaction = void 0;
 const constants_1 = require("../../utils/constants");
 const SignedTransaction_1 = require("./SignedTransaction");
 class PushTransaction extends SignedTransaction_1.SignedTransaction {
-    constructor({ action, account, authPermission, data, encryptOptions = {}, }) {
+    constructor({ action, account, authPermission, data, encryptOptions = {}, signingAccount, }) {
         super();
         this.ENDPOINT = 'chain/push_transaction';
         this.ACTION = '';
@@ -16,13 +16,14 @@ class PushTransaction extends SignedTransaction_1.SignedTransaction {
         this.data = data;
         this.encryptOptions = encryptOptions;
         this.authPermission = authPermission;
+        this.signingAccount = signingAccount;
     }
     getData() {
         const data = Object.assign({}, this.data);
         if (data.content && this.encryptOptions && this.encryptOptions.key && this.encryptOptions.contentType) {
             data.content = this.getCipherContent(this.encryptOptions.contentType, data.content, this.privateKey, this.encryptOptions.key);
         }
-        return Object.assign(Object.assign({}, data), { actor: this.data.actor != null && this.data.actor !== '' ? this.data.actor : this.getActor(), permission: this.data.permission || 'active' });
+        return Object.assign(Object.assign({}, data), { actor: this.data.actor != null && this.data.actor !== '' ? this.data.actor : this.getActor() });
     }
 }
 exports.PushTransaction = PushTransaction;

--- a/lib/transactions/signed/PushTransaction.js
+++ b/lib/transactions/signed/PushTransaction.js
@@ -4,7 +4,7 @@ exports.PushTransaction = void 0;
 const constants_1 = require("../../utils/constants");
 const SignedTransaction_1 = require("./SignedTransaction");
 class PushTransaction extends SignedTransaction_1.SignedTransaction {
-    constructor(action, account, data, encryptOptions = {}) {
+    constructor({ action, account, authPermission, data, encryptOptions = {}, }) {
         super();
         this.ENDPOINT = 'chain/push_transaction';
         this.ACTION = '';
@@ -15,6 +15,7 @@ class PushTransaction extends SignedTransaction_1.SignedTransaction {
         }
         this.data = data;
         this.encryptOptions = encryptOptions;
+        this.authPermission = authPermission;
     }
     getData() {
         const data = Object.assign({}, this.data);

--- a/lib/transactions/signed/SignedTransaction.js
+++ b/lib/transactions/signed/SignedTransaction.js
@@ -40,6 +40,7 @@ class SignedTransaction extends Transactions_1.Transactions {
                 action: this.getAction(),
                 authPermission: this.getAuthPermission(),
                 data: this.getData(),
+                signingAccount: this.getSigningAccount(),
             });
             const result = yield this.pushToServer(rawTransaction, this.getEndPoint(), dryRun);
             return this.prepareResponse(result);
@@ -56,6 +57,9 @@ class SignedTransaction extends Transactions_1.Transactions {
     }
     getAuthPermission() {
         return this.authPermission;
+    }
+    getSigningAccount() {
+        return this.signingAccount;
     }
     getEndPoint() {
         return this.ENDPOINT;

--- a/lib/transactions/signed/SignedTransaction.js
+++ b/lib/transactions/signed/SignedTransaction.js
@@ -38,6 +38,7 @@ class SignedTransaction extends Transactions_1.Transactions {
             const rawTransaction = yield this.createRawTransaction({
                 account: this.getAccount(),
                 action: this.getAction(),
+                authPermission: this.getAuthPermission(),
                 data: this.getData(),
             });
             const result = yield this.pushToServer(rawTransaction, this.getEndPoint(), dryRun);
@@ -52,6 +53,9 @@ class SignedTransaction extends Transactions_1.Transactions {
     }
     getAccount() {
         return this.ACCOUNT;
+    }
+    getAuthPermission() {
+        return this.authPermission;
     }
     getEndPoint() {
         return this.ENDPOINT;

--- a/src/FIOSDK.ts
+++ b/src/FIOSDK.ts
@@ -1403,16 +1403,16 @@ export class FIOSDK {
       const { fee: stakeFee } = await this.getFee(EndPoint.stakeFioTokens, fioAddress)
       fee = stakeFee
     }
-    return this.pushTransaction(
-      'fio.staking',
-      'stakefio',
-      {
+    return this.pushTransaction({
+      account: 'fio.staking',
+      action: 'stakefio',
+      data: {
         amount,
         fio_address: fioAddress,
         max_fee: fee,
         tpid: technologyProviderId,
       },
-    )
+    })
   }
 
   /**
@@ -1433,16 +1433,16 @@ export class FIOSDK {
       const { fee: stakeFee } = await this.getFee(EndPoint.unStakeFioTokens, fioAddress)
       fee = stakeFee
     }
-    return this.pushTransaction(
-      'fio.staking',
-      'unstakefio',
-      {
+    return this.pushTransaction({
+      account: 'fio.staking',
+      action: 'unstakefio',
+      data: {
         amount,
         fio_address: fioAddress,
         max_fee: fee,
         tpid: technologyProviderId,
       },
-    )
+    })
   }
 
   /**
@@ -1460,12 +1460,19 @@ export class FIOSDK {
    * @param data JSON object with params for action
    * @param encryptOptions JSON object with params for encryption
    */
-  public async pushTransaction(
+  public async pushTransaction({
+    account,
+    action,
+    data,
+    authPermission,
+    encryptOptions = {},
+  }: {
     account: string,
     action: string,
     data: any,
-    encryptOptions: EncryptOptions = {},
-  ): Promise<any> {
+    authPermission?: string,
+    encryptOptions?: EncryptOptions,
+}): Promise<any> {
     data.tpid = this.getTechnologyProviderId(data.tpid)
     if (data.content && !encryptOptions.key) {
       switch (action) {
@@ -1485,12 +1492,13 @@ export class FIOSDK {
         //
       }
     }
-    const pushTransaction = new SignedTransactions.PushTransaction(
+    const pushTransaction = new SignedTransactions.PushTransaction({
       action,
       account,
+      authPermission,
       data,
       encryptOptions,
-    )
+})
     return pushTransaction.execute(this.privateKey, this.publicKey, this.returnPreparedTrx)
   }
 
@@ -1774,7 +1782,13 @@ export class FIOSDK {
       case 'getMultiplier':
         return this.getMultiplier()
       case 'pushTransaction':
-        return this.pushTransaction(params.account, params.action, params.data, params.encryptOptions)
+        return this.pushTransaction({
+          account: params.account,
+          action: params.action,
+          data: params.data,
+          authPermission: params.authPermission,
+          encryptOptions: params.encryptOptions,
+        })
       case 'getAccountPubKey':
         return this.getAccountPubKey(params.account)
       case 'getEncryptKey':

--- a/src/FIOSDK.ts
+++ b/src/FIOSDK.ts
@@ -1466,12 +1466,14 @@ export class FIOSDK {
     data,
     authPermission,
     encryptOptions = {},
+    signingAccount,
   }: {
     account: string,
     action: string,
     data: any,
     authPermission?: string,
     encryptOptions?: EncryptOptions,
+    signingAccount?: string,
 }): Promise<any> {
     data.tpid = this.getTechnologyProviderId(data.tpid)
     if (data.content && !encryptOptions.key) {
@@ -1498,6 +1500,7 @@ export class FIOSDK {
       authPermission,
       data,
       encryptOptions,
+      signingAccount,
 })
     return pushTransaction.execute(this.privateKey, this.publicKey, this.returnPreparedTrx)
   }
@@ -1788,6 +1791,7 @@ export class FIOSDK {
           data: params.data,
           authPermission: params.authPermission,
           encryptOptions: params.encryptOptions,
+          signingAccount: params.signingAccount,
         })
       case 'getAccountPubKey':
         return this.getAccountPubKey(params.account)

--- a/src/entities/Autorization.ts
+++ b/src/entities/Autorization.ts
@@ -1,6 +1,6 @@
 export class Autorization {
   public actor: string
-  public permission: string
+  public permission?: string
 
   constructor(actor: string, permission = 'active') {
     this.actor = actor

--- a/src/entities/RawAction.ts
+++ b/src/entities/RawAction.ts
@@ -5,4 +5,5 @@ export class RawAction {
   public name: string = '' // 'transfer',
   public authorization: Autorization[] = new Array<Autorization>()
   public data: any
+  public actor: string | undefined
 }

--- a/src/transactions/Transactions.ts
+++ b/src/transactions/Transactions.ts
@@ -93,6 +93,7 @@ export class Transactions {
 
   public expirationOffset: number = Constants.defaultExpirationOffset
   public authPermission: string | undefined
+  public signingAccount: string | undefined
 
   public getActor(publicKey: string = ''): string {
     return Transactions.FioProvider.accountHash((publicKey === '' || !publicKey) ? this.publicKey : publicKey)
@@ -224,17 +225,18 @@ export class Transactions {
   }
 
   public async createRawTransaction(
-    { account, action, authPermission, data, publicKey, chainData }: {
+    { account, action, authPermission, data, publicKey, chainData, signingAccount }: {
       account: string;
       action: string;
       authPermission?: string;
-      data: any,
-      publicKey?: string,
+      data: any;
+      publicKey?: string;
       chainData?: {
         ref_block_num: number,
         ref_block_prefix: number,
         expiration: string,
-      }
+      };
+      signingAccount?: string;
     },
   ): Promise<RawTransaction> {
     const rawTransaction = new RawTransaction()
@@ -250,6 +252,7 @@ export class Transactions {
     rawaction.account = account
     rawaction.name = action
     rawaction.data = data
+    rawaction.actor = signingAccount
     rawTransaction.actions.push(rawaction)
 
     if (chainData && chainData.ref_block_num) {

--- a/src/transactions/Transactions.ts
+++ b/src/transactions/Transactions.ts
@@ -92,6 +92,7 @@ export class Transactions {
   public validationRules: any | null = null
 
   public expirationOffset: number = Constants.defaultExpirationOffset
+  public authPermission: string | undefined
 
   public getActor(publicKey: string = ''): string {
     return Transactions.FioProvider.accountHash((publicKey === '' || !publicKey) ? this.publicKey : publicKey)
@@ -223,9 +224,10 @@ export class Transactions {
   }
 
   public async createRawTransaction(
-    { account, action, data, publicKey, chainData }: {
+    { account, action, authPermission, data, publicKey, chainData }: {
       account: string;
       action: string;
+      authPermission?: string;
       data: any,
       publicKey?: string,
       chainData?: {
@@ -244,7 +246,7 @@ export class Transactions {
       data.actor = actor
     }
 
-    rawaction.authorization.push(new Autorization(data.actor, data.permission))
+    rawaction.authorization.push(new Autorization(data.actor, authPermission))
     rawaction.account = account
     rawaction.name = action
     rawaction.data = data

--- a/src/transactions/signed/PushTransaction.ts
+++ b/src/transactions/signed/PushTransaction.ts
@@ -10,18 +10,27 @@ export class PushTransaction extends SignedTransaction {
   public ACCOUNT: string = Constants.defaultAccount
   public data: any
   public encryptOptions: EncryptOptions
+  public authPermission: string | undefined
 
-  constructor(
+  constructor({
+    action,
+    account,
+    authPermission,
+    data,
+    encryptOptions = {},
+  }: {
     action: string,
     account: string,
+    authPermission: string | undefined,
     data: any,
-    encryptOptions: EncryptOptions = {},
-  ) {
+    encryptOptions: EncryptOptions,
+}) {
     super()
     this.ACTION = action
     if (account) { this.ACCOUNT = account }
     this.data = data
     this.encryptOptions = encryptOptions
+    this.authPermission = authPermission
   }
 
   public getData(): any {

--- a/src/transactions/signed/PushTransaction.ts
+++ b/src/transactions/signed/PushTransaction.ts
@@ -11,6 +11,7 @@ export class PushTransaction extends SignedTransaction {
   public data: any
   public encryptOptions: EncryptOptions
   public authPermission: string | undefined
+  public signingAccount: string | undefined
 
   constructor({
     action,
@@ -18,12 +19,14 @@ export class PushTransaction extends SignedTransaction {
     authPermission,
     data,
     encryptOptions = {},
+    signingAccount,
   }: {
     action: string,
     account: string,
     authPermission: string | undefined,
     data: any,
     encryptOptions: EncryptOptions,
+    signingAccount: string | undefined,
 }) {
     super()
     this.ACTION = action
@@ -31,6 +34,7 @@ export class PushTransaction extends SignedTransaction {
     this.data = data
     this.encryptOptions = encryptOptions
     this.authPermission = authPermission
+    this.signingAccount = signingAccount
   }
 
   public getData(): any {
@@ -47,7 +51,6 @@ export class PushTransaction extends SignedTransaction {
     return {
       ...data,
       actor: this.data.actor != null && this.data.actor !== '' ? this.data.actor : this.getActor(),
-      permission: this.data.permission || 'active',
     }
   }
 

--- a/src/transactions/signed/SignedTransaction.ts
+++ b/src/transactions/signed/SignedTransaction.ts
@@ -44,6 +44,7 @@ export abstract class SignedTransaction extends Transactions {
   public abstract getData(): any
 
   public static authPermission: string | undefined
+  public static signingAccount: string | undefined
   public static expirationOffset: number
 
   public async execute(privateKey: string, publicKey: string, dryRun = false, expirationOffset = Constants.defaultExpirationOffset): Promise<any> {
@@ -56,6 +57,7 @@ export abstract class SignedTransaction extends Transactions {
       action: this.getAction(),
       authPermission: this.getAuthPermission(),
       data: this.getData(),
+      signingAccount: this.getSigningAccount(),
     })
 
     const result = await this.pushToServer(rawTransaction, this.getEndPoint(), dryRun)
@@ -76,6 +78,10 @@ export abstract class SignedTransaction extends Transactions {
 
   public getAuthPermission(): string | undefined {
     return this.authPermission
+  }
+
+  public getSigningAccount(): string | undefined {
+    return this.signingAccount
   }
 
   public getEndPoint(): string {

--- a/src/transactions/signed/SignedTransaction.ts
+++ b/src/transactions/signed/SignedTransaction.ts
@@ -43,6 +43,7 @@ export abstract class SignedTransaction extends Transactions {
 
   public abstract getData(): any
 
+  public static authPermission: string | undefined
   public static expirationOffset: number
 
   public async execute(privateKey: string, publicKey: string, dryRun = false, expirationOffset = Constants.defaultExpirationOffset): Promise<any> {
@@ -53,6 +54,7 @@ export abstract class SignedTransaction extends Transactions {
     const rawTransaction = await this.createRawTransaction({
       account: this.getAccount(),
       action: this.getAction(),
+      authPermission: this.getAuthPermission(),
       data: this.getData(),
     })
 
@@ -70,6 +72,10 @@ export abstract class SignedTransaction extends Transactions {
 
   public getAccount(): string {
     return this.ACCOUNT
+  }
+
+  public getAuthPermission(): string | undefined {
+    return this.authPermission
   }
 
   public getEndPoint(): string {

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -9,7 +9,13 @@ const fetchJson = async (uri, opts = {}) => {
   return fetch(uri, opts)
 }
 
-let privateKey, publicKey, privateKey2, publicKey2, testFioAddressName, testFioAddressName2
+let privateKey,
+  publicKey,
+  privateKey2,
+  publicKey2,
+  testFioAddressName,
+  testFioAddressName2,
+  testFioDomainName
 const mnemonic = 'property follow talent guilt uncover someone gain powder urge slot taxi sketch'
 const mnemonic2 = 'round work clump little air glue lemon gravity shed charge assault orbit'
 
@@ -791,6 +797,131 @@ describe('Testing generic actions', () => {
   //   expect(result.encrypt_public_key).to.be.a('string')
   // })
 })
+
+describe('Test addaddress on account with permissions', () => {
+  const account1 = FIOSDK.accountHash(publicKey).accountnm;
+  const account2 = FIOSDK.accountHash(publicKey2).accountnm;
+
+  const permissionName = 'addmyadd'; // Must be < 12 chars
+
+  it(`user1 creates addmyadd permission and assigns to user2`, async () => {
+    try {
+      const authorization_object = {
+        threshold: 1,
+        accounts: [
+          {
+            permission: {
+              actor: account2,
+              permission: 'active',
+            },
+            weight: 1,
+          },
+        ],
+        keys: [],
+        waits: [],
+      };
+
+      const result = await fioSdk.genericAction('pushTransaction', {
+        action: 'updateauth',
+        account: 'eosio',
+        actor: account1,
+        data: {
+          permission: permissionName, //addmyadd
+          parent: 'active',
+          max_fee: defaultFee,
+          auth: authorization_object,
+          account: account1,
+        },
+      });
+
+      expect(result).to.have.all.keys(
+        'transaction_id',
+        'block_num',
+        'block_time'
+      );
+      expect(result.block_num).to.be.a('number');
+      expect(result.transaction_id).to.be.a('string');
+    } catch (e) {
+      console.log(e);
+    }
+  });
+
+  it(`user1 links regmyadd permission to regaddress`, async () => {
+    try {
+      const result = await fioSdk.genericAction('pushTransaction', {
+        action: 'linkauth',
+        account: 'eosio',
+        actor: account1,
+        data: {
+          account: account1, // the owner of the permission to be linked, this account will sign the transaction
+          code: 'fio.address', // the contract owner of the action to be linked
+          type: 'addaddress', // the action to be linked
+          requirement: permissionName, // the name of the custom permission (created by updateauth)
+          max_fee: defaultFee,
+        },
+      });
+
+      expect(result).to.have.all.keys(
+        'transaction_id',
+        'block_num',
+        'block_time'
+      );
+      expect(result.block_num).to.be.a('number');
+      expect(result.transaction_id).to.be.a('string');
+    } catch (e) {
+      console.log(e);
+    }
+  });
+
+  it(`renewdomain for user1`, async () => {
+    try {
+      const result = await fioSdk.genericAction('pushTransaction', {
+        action: 'renewdomain',
+        account: 'fio.address',
+        authPermission: 'active',
+        data: {
+          fio_domain: testFioDomainName,
+          max_fee: defaultFee,
+          tpid: '',
+          actor: account1,
+        },
+      });
+
+      expect(result.status).to.equal('OK');
+    } catch (e) {
+      console.log(e);
+    }
+  });
+
+  it(`addaddress as user2`, async () => {
+    try {
+      const result = await fioSdk.genericAction('pushTransaction', {
+        action: 'addaddress',
+        account: 'fio.address',
+        signingAccount: account2,
+        authPermission: permissionName,
+        data: {
+          fio_address: testFioAddressName,
+          public_addresses: [
+            {
+              chain_code: 'BCH',
+              token_code: 'BCH',
+              public_address:
+                'bitcoincash:qzf8zha74ahdh9j0xnwlffdn0zuyaslx3c90q7n9g9',
+            },
+          ],
+          max_fee: defaultFee,
+          tpid: '',
+          actor: account1,
+        },
+      });
+      
+      expect(result.status).to.equal('OK');
+    } catch (e) {
+      console.log(e);
+    }
+  });
+});
 
 describe('Staking tests', () => {
   let stakedBalance = 0;


### PR DESCRIPTION
- Use authPermission in sign/push transaction. 
- Receive params for pushTransaction in object instead of multiple arguments
- Update documentation