### PR TITLE
Fix. DASH-627 Handle empty response

### DIFF
--- a/lib/transactions/signed/SignedTransaction.js
+++ b/lib/transactions/signed/SignedTransaction.js
@@ -22,7 +22,7 @@ class SignedTransaction extends Transactions_1.Transactions {
     }
     static parseProcessedResult(processed) {
         try {
-            if (!processed.action_traces[0].receipt.response || typeof processed.action_traces[0].receipt.response !== 'object')
+            if (!processed.action_traces[0].receipt.response)
                 return {};
             return JSON.parse(processed.action_traces[0].receipt.response);
         }

--- a/src/transactions/signed/SignedTransaction.ts
+++ b/src/transactions/signed/SignedTransaction.ts
@@ -28,7 +28,7 @@ export abstract class SignedTransaction extends Transactions {
 
   public static parseProcessedResult(processed: { action_traces: Array<{ receipt: { response: string }}>}) {
     try {
-      if (!processed.action_traces[0].receipt.response || typeof processed.action_traces[0].receipt.response !== 'object') return {}
+      if (!processed.action_traces[0].receipt.response) return {}
       return JSON.parse(processed.action_traces[0].receipt.response)
     } catch (e) {
       // tslint:disable-next-line:no-console

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -109,7 +109,7 @@ before(async () => {
     fetchJson
   )
   await fioSdkFaucet.transferTokens(publicKey, fundAmount * 4, defaultFee)
-  await fioSdkFaucet.transferTokens(publicKey2, fundAmount, defaultFee)
+  await fioSdkFaucet.transferTokens(publicKey2, fundAmount * 4, defaultFee)
   await timeout(receiveTransferTimout)
 
   try {
@@ -312,7 +312,9 @@ describe('Testing generic actions', () => {
       FIOSDK.isFioDomainValid('$%FG%')
     } catch (e) {
       console.log(e)
-      expect(e.list[0].message).to.equal('fioDomain must match /^[a-z0-9\\-]+$/i.')
+      expect(e.list[0].message).to.equal(
+        'fioDomain must match /^[a-zA-Z0-9]{1}(?:(?:(?!-{2,}))[a-zA-Z0-9-]*[a-zA-Z0-9]+){0,1}$/i.'
+      );
     }
     try {
       FIOSDK.isFioPublicKeyValid('dfsd')


### PR DESCRIPTION
- Fix on locatest fioDomain validation message
- Fix on localtest faucet amount for 2-nd walet
- Fix handing empty response results in `parseProcessedResult`